### PR TITLE
fix(ThingSpeak): исправление ограничения частоты и тестов

### DIFF
--- a/test/test_thingspeak_rate_limiting.py
+++ b/test/test_thingspeak_rate_limiting.py
@@ -5,7 +5,6 @@
 """
 
 import sys
-import time
 
 def test_thingspeak_rate_limiting_logic():
     """Тест логики ограничения частоты ThingSpeak"""
@@ -38,10 +37,7 @@ def test_thingspeak_rate_limiting_logic():
             return False
         
         # Проверяем обычный интервал отправки (точно как в C++)
-        if (current_time - last_ts_publish) < THINGSPEAK_INTERVAL:
-            return False
-        
-        return True
+        return (current_time - last_ts_publish) >= THINGSPEAK_INTERVAL
     
     def simulate_send_attempt(success, current_time):
         """Симуляция попытки отправки"""


### PR DESCRIPTION
##  Исправления ThingSpeak

###  Проблемы решены:
1. **Ограничение частоты** - добавлена функция canSendToThingSpeak() с проверкой интервалов
2. **Блокировка при ошибках** - система отключается на 1 час при 10+ ошибках подряд
3. **Восстановление** - автоматическое восстановление после истечения блокады
4. **Тесты** - полная синхронизация Python тестов с C++ логикой

###  Результаты тестирования:
-  Все 2/2 теста ThingSpeak прошли успешно
-  Логика ограничения частоты работает корректно
-  Обработка ошибок функционирует правильно
-  Система восстановления после блокировки активна

###  Архитектурные изменения:
- Переменные lastTsPublish, lastFailTime, consecutiveFailCount вынесены в глобальную область
- Функция canSendToThingSpeak() экспортируется для использования в main.cpp
- Исправлены ошибки линковки и архитектурной согласованности

###  Тестирование:
`ash
python test/test_thingspeak_rate_limiting.py
# Результат: 2/2 тестов прошли успешно
`

Closes #issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified and streamlined the test suite for ThingSpeak rate limiting, replacing class-based tests with procedural test functions for easier readability and maintenance.

* **Tests**
  * Improved coverage and clarity of rate limiting and error handling scenarios with more direct and self-contained test functions.
  * Enhanced reporting of test results and error messages for better usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->